### PR TITLE
Use public HumanEval dataset in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,18 @@
 
 ## Project Goals
 - Develop budget-conscious evaluations for large language models (LLMs).
-- Start with the HumanEval+ dataset and expand to track performance at different cost budgets (e.g., $1 vs. $5).
+- Start with the HumanEval dataset and expand to track performance at different cost budgets (e.g., $1 vs. $5).
 
 ## Environment
 - Python project managed with [uv](https://github.com/astral-sh/uv).
 - Dependencies are declared in `pyproject.toml` and installed with `uv`.
-- Requires access to the gated `openai_humaneval_plus` dataset from the Hugging Face Hub.
-  - Set the environment variable `HF_AUTH_TOKEN` (or `HUGGINGFACE_HUB_TOKEN`) with a valid token that has accepted the dataset's license.
+- Requires access to the `openai/openai_humaneval` dataset from the Hugging Face Hub, which is publicly available.
   - Network access to `huggingface.co` is required for dataset download.
 
 ## Tests
 - Run tests with:
   - `uv run pytest`
-- Tests rely on the official HumanEval+ evaluation utilities.
-- If dataset access fails, tests are skipped. Ensure authentication before running.
+- Tests rely on the official HumanEval evaluation utilities.
 
 ## Notes
 - Do not commit secrets (tokens or API keys).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ BudgetBench: A cost-aware benchmark for LLM coding. Tracks HumanEval+ pass@k alo
 
 ## Development
 
-This project uses [uv](https://github.com/astral-sh/uv) for dependency management and relies on the official HumanEval+ dataset and evaluation library.
+This project uses [uv](https://github.com/astral-sh/uv) for dependency management and relies on the public HumanEval dataset and evaluation library.
 
 ```bash
 uv sync
 uv run pytest
 ```
 
-The included tests download the ``openai_humaneval_plus`` dataset and evaluate two of its problems (palindrome and FizzBuzz) with correct, partially correct, and incorrect solutions using the official ``human_eval`` executor.
+The included tests download the ``openai/openai_humaneval`` dataset and evaluate two of its problems (``make_palindrome`` and ``fizz_buzz``) with correct, partially correct, and incorrect solutions using the official ``human_eval`` executor.

--- a/budgetbench/evaluator.py
+++ b/budgetbench/evaluator.py
@@ -8,11 +8,12 @@ from typing import Any, Dict, Tuple
 from human_eval.execution import check_correctness
 
 
-def evaluate(problem: Dict[str, Any], solution: str) -> Tuple[int, int]:
+def evaluate(problem: Dict[str, Any], solution: str, timeout: float = 1.0) -> Tuple[int, int]:
     """Return number of passed tests and total tests for a dataset problem.
 
     The implementation delegates execution to ``human_eval.execution.check_correctness``
     for each individual assertion in the problem's test suite.
+    ``timeout`` controls how long each individual test is allowed to run.
     """
 
     module_ast = ast.parse(problem["test"])
@@ -36,7 +37,7 @@ def evaluate(problem: Dict[str, Any], solution: str) -> Tuple[int, int]:
         test_module = ast.Module(body=[test_func], type_ignores=[])
         test_src = ast.unparse(ast.fix_missing_locations(test_module))
         single_problem = {**problem, "test": test_src}
-        result = check_correctness(single_problem, solution)
+        result = check_correctness(single_problem, solution, timeout)
         if result.get("passed"):
             passed += 1
     return passed, total


### PR DESCRIPTION
## Summary
- add timeout parameter to evaluator's `check_correctness` calls
- rewrite tests to use public `openai/openai_humaneval` tasks (`make_palindrome` and `fizz_buzz`)
- update docs to match new dataset

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5918d85bc832bbb1ea28abdae98d9