### PR TITLE
Ensure .env fallback and robust Hello World integration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@
 
 ## Tests
 - Run tests with:
-  - `uv run pytest`
+  - `uv run pytest` – run all tests (fails if `OPENAI_API_KEY` or `OPENAI_BASE_URL` are unset)
+  - `uv run pytest -m integration` – run only integration tests
+  - `uv run pytest -m "not integration"` – run tests excluding integration
+- Integration tests require `OPENAI_API_KEY` and `OPENAI_BASE_URL` to be set; otherwise they will fail.
 - Tests rely on the official HumanEval evaluation utilities.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ This project uses [uv](https://github.com/astral-sh/uv) for dependency managemen
 
 ```bash
 uv sync
-uv run pytest
+uv run pytest                # run all tests
+uv run pytest -m integration # run only integration tests
+uv run pytest -m "not integration" # run tests excluding integration
 ```
 
 The included tests download the ``openai/openai_humaneval`` dataset and evaluate two of its problems (``make_palindrome`` and ``fizz_buzz``) with correct, partially correct, and incorrect solutions using the official ``human_eval`` executor.
 
 ### LLM integration tests
 
-Integration tests that exercise an OpenAI-compatible LLM provider require these environment variables:
+Integration tests exercise an OpenAI-compatible LLM provider and require these environment variables to be set **or the tests will fail**:
 
 * `OPENAI_BASE_URL` – API endpoint (e.g. `https://openrouter.ai/api/v1`).
 * `OPENAI_API_KEY` – secret API token.
 
-The tests default to the `openai/gpt-oss-20B` model and are skipped automatically if the variables are unset.
-The CI workflow sets `OPENAI_BASE_URL` to `https://openrouter.ai/api/v1`, `MODEL_NAME` to `openai/gpt-oss-20B`, and expects `OPENAI_API_KEY` to be supplied via a repository secret of the same name.
+The tests default to the `openai/gpt-oss-20b` model. The CI workflow sets `OPENAI_BASE_URL` to `https://openrouter.ai/api/v1`, `MODEL_NAME` to `openai/gpt-oss-20b`, and expects `OPENAI_API_KEY` to be supplied via a repository secret of the same name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "datasets",
     "human-eval",
     "openai>=1.0.0",
+    "python-dotenv>=1.1.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/budgetbench/llm.py
+++ b/src/budgetbench/llm.py
@@ -5,11 +5,30 @@ from __future__ import annotations
 import os
 from openai import OpenAI
 
-MODEL_NAME = os.getenv("MODEL_NAME", "openai/gpt-oss-20B")
+MODEL_NAME = os.getenv("MODEL_NAME", "openai/gpt-oss-20b")
+
+
+def _ensure_env() -> None:
+    """Load API credentials from ``.env`` when missing."""
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("OPENAI_BASE_URL"):
+        from dotenv import load_dotenv
+
+        load_dotenv()
+
+    missing = [
+        name
+        for name in ["OPENAI_API_KEY", "OPENAI_BASE_URL"]
+        if not os.getenv(name)
+    ]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
 
 
 def chat_completion(prompt: str, model: str | None = None) -> str:
     """Return the assistant message for a prompt using OpenAI-compatible API."""
+    _ensure_env()
     client = OpenAI(
         api_key=os.environ["OPENAI_API_KEY"],
         base_url=os.environ["OPENAI_BASE_URL"],
@@ -17,6 +36,6 @@ def chat_completion(prompt: str, model: str | None = None) -> str:
     completion = client.chat.completions.create(
         model=model or MODEL_NAME,
         messages=[{"role": "user", "content": prompt}],
-        max_tokens=10,
+        max_tokens=200,
     )
     return completion.choices[0].message.content

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -3,15 +3,19 @@
 import os
 
 import pytest
+from dotenv import load_dotenv
 
 from budgetbench.llm import chat_completion
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    not os.getenv("OPENAI_API_KEY") or not os.getenv("OPENAI_BASE_URL"),
-    reason="OPENAI_API_KEY and OPENAI_BASE_URL must be set for integration test",
-)
 def test_openai_hello_world():
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("OPENAI_BASE_URL"):
+        load_dotenv()
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("OPENAI_BASE_URL"):
+        pytest.fail(
+            "OPENAI_API_KEY and OPENAI_BASE_URL must be set for integration test",
+        )
     result = chat_completion("Say hello world")
-    assert "hello world" in result.lower()
+    normalized = result.lower().replace(",", "")
+    assert "hello world" in normalized

--- a/uv.lock
+++ b/uv.lock
@@ -166,6 +166,7 @@ dependencies = [
     { name = "human-eval" },
     { name = "openai" },
     { name = "pytest" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
@@ -174,6 +175,7 @@ requires-dist = [
     { name = "human-eval" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 
 [[package]]
@@ -1245,6 +1247,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- load `.env` when either API key or base URL is missing and bump `max_tokens` for chat completions
- normalize punctuation in the OpenAI integration test so minor formatting doesn't break it

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60455c838832bbdb43b95a5dd5bb2