### PR TITLE
feat: parameterize token limit for LLM calls

### DIFF
--- a/src/budgetbench/llm.py
+++ b/src/budgetbench/llm.py
@@ -23,7 +23,11 @@ def _ensure_env() -> None:
         raise RuntimeError("Missing required environment variable: OPENAI_API_KEY")
 
 
-def chat_completion(prompt: str, model: str | None = None) -> str:
+def chat_completion(
+    prompt: str,
+    model: str | None = None,
+    max_tokens: int = 10_240,
+) -> str:
     """Return the assistant message for a prompt using OpenAI-compatible API."""
     _ensure_env()
     client_kwargs = {"api_key": os.environ["OPENAI_API_KEY"]}
@@ -34,6 +38,6 @@ def chat_completion(prompt: str, model: str | None = None) -> str:
     completion = client.chat.completions.create(
         model=model or MODEL_NAME,
         messages=[{"role": "user", "content": prompt}],
-        max_tokens=200,
+        max_tokens=max_tokens,
     )
     return completion.choices[0].message.content

--- a/src/budgetbench/runner.py
+++ b/src/budgetbench/runner.py
@@ -1,0 +1,80 @@
+"""End-to-end utilities for running HumanEval tasks with an LLM."""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import Any, Dict
+
+from datasets import load_dataset
+
+from .llm import chat_completion
+from .evaluator import evaluate
+
+
+def _extract_code(text: str) -> str:
+    """Extract Python code from an LLM response.
+
+    The helper searches for fenced code blocks (```python ... ```). When none are
+    present the raw text is returned. Leading and trailing whitespace is removed.
+    """
+    fences = re.findall(r"```(?:python)?\n(.*?)```", text, re.IGNORECASE | re.DOTALL)
+    if fences:
+        return fences[0].strip()
+    return text.strip()
+
+
+def _is_valid_python(code: str) -> bool:
+    """Return True if ``code`` parses as valid Python."""
+    try:
+        ast.parse(code)
+        return True
+    except SyntaxError:
+        return False
+
+
+def _has_valid_signature(code: str, prompt: str, entry_point: str) -> bool:
+    """Check that ``code`` defines ``entry_point`` with the same arguments as ``prompt``."""
+    try:
+        solution_tree = ast.parse(code)
+        prompt_tree = ast.parse(prompt)
+    except SyntaxError:
+        return False
+    expected = next(
+        node for node in prompt_tree.body if isinstance(node, ast.FunctionDef)
+    )
+    expected_args = [arg.arg for arg in expected.args.args]
+    for node in solution_tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == entry_point:
+            given_args = [arg.arg for arg in node.args.args]
+            return given_args == expected_args
+    return False
+
+
+def run_humaneval_task(
+    task_id: str,
+    model: str,
+    max_tokens: int = 10_240,
+) -> Dict[str, Any]:
+    """Generate and evaluate a HumanEval task using ``model``.
+
+    The returned dictionary contains the raw LLM output (``raw``), the extracted
+    code (``code``), booleans for syntax validity (``is_valid``) and API
+    compliance (``has_valid_signature``), along with the evaluation results
+    (``passed`` and ``total``).
+    """
+    dataset = load_dataset("openai/openai_humaneval", split="test")
+    problem = next(p for p in dataset if p["task_id"] == task_id)
+    raw = chat_completion(problem["prompt"], model=model, max_tokens=max_tokens)
+    code = _extract_code(raw)
+    is_valid = _is_valid_python(code)
+    has_valid_signature = _has_valid_signature(code, problem["prompt"], problem["entry_point"])
+    passed, total = evaluate(problem, code)
+    return {
+        "raw": raw,
+        "code": code,
+        "is_valid": is_valid,
+        "has_valid_signature": has_valid_signature,
+        "passed": passed,
+        "total": total,
+    }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,19 @@
+"""Integration tests for running HumanEval tasks end-to-end."""
+
+import pytest
+
+from budgetbench.runner import run_humaneval_task
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "task_id",
+    ["HumanEval/10", "HumanEval/36"],
+    ids=["palindrome", "fizz_buzz"],
+)
+def test_run_humaneval_task(task_id):
+    result = run_humaneval_task(task_id, model="openai/gpt-oss-120b")
+    assert result["is_valid"], "model did not produce valid Python code"
+    assert result["has_valid_signature"], "model did not follow required API"
+    assert result["total"] > 0
+    assert 0 <= result["passed"] <= result["total"]


### PR DESCRIPTION
## Summary
- allow configuring `max_tokens` in `chat_completion` and `run_humaneval_task`

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration` *(fails: model did not produce valid Python code)*

------
https://chatgpt.com/codex/tasks/task_e_68b628bb5f84832b8a5c6869875eff40