### PR TITLE
Track token usage and cost for LLM calls

### DIFF
--- a/src/budgetbench/llm_cost.py
+++ b/src/budgetbench/llm_cost.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LLMCost:
+    """Pricing information for an LLM on OpenRouter."""
+
+    name: str
+    prompt: float
+    completion: float
+    cache: float = 0.0
+    reasoning: float = 0.0
+
+
+LLM_COSTS: dict[str, LLMCost] = {
+    "openai/gpt-oss-120b": LLMCost(
+        name="openai/gpt-oss-120b", prompt=0.000000072, completion=0.00000028
+    ),
+    "openai/gpt-oss-20b": LLMCost(
+        name="openai/gpt-oss-20b", prompt=0.00000004, completion=0.00000015
+    ),
+    "openai/gpt-5": LLMCost(
+        name="openai/gpt-5",
+        prompt=0.00000125,
+        completion=0.00001,
+        cache=0.000000125,
+    ),
+    "openai/gpt-5-nano": LLMCost(
+        name="openai/gpt-5-nano",
+        prompt=0.00000005,
+        completion=0.0000004,
+        cache=0.000000005,
+    ),
+    "openai/gpt-5-mini": LLMCost(
+        name="openai/gpt-5-mini",
+        prompt=0.00000025,
+        completion=0.000002,
+        cache=0.000000025,
+    ),
+    "moonshotai/kimi-k2": LLMCost(
+        name="moonshotai/kimi-k2",
+        prompt=0.00000014,
+        completion=0.00000249,
+    ),
+    "qwen/qwen3-30b-a3b": LLMCost(
+        name="qwen/qwen3-30b-a3b",
+        prompt=0.00000001999188,
+        completion=0.0000000800064,
+    ),
+    "qwen/qwen3-coder": LLMCost(
+        name="qwen/qwen3-coder",
+        prompt=0.0000002,
+        completion=0.0000008,
+    ),
+    "z-ai/glm-4.5": LLMCost(
+        name="z-ai/glm-4.5",
+        prompt=0.00000032986602,
+        completion=0.0000013201056,
+    ),
+    "anthropic/claude-sonnet-4": LLMCost(
+        name="anthropic/claude-sonnet-4",
+        prompt=0.000003,
+        completion=0.000015,
+        cache=0.0000003,
+    ),
+    "anthropic/claude-opus-4": LLMCost(
+        name="anthropic/claude-opus-4",
+        prompt=0.000015,
+        completion=0.000075,
+        cache=0.0000015,
+    ),
+    "x-ai/grok-code-fast-1": LLMCost(
+        name="x-ai/grok-code-fast-1",
+        prompt=0.0000002,
+        completion=0.0000015,
+        cache=0.00000002,
+    ),
+    "google/gemini-2.5-flash": LLMCost(
+        name="google/gemini-2.5-flash",
+        prompt=0.0000003,
+        completion=0.0000025,
+        cache=0.000000075,
+    ),
+    "google/gemini-2.5-pro": LLMCost(
+        name="google/gemini-2.5-pro",
+        prompt=0.00000125,
+        completion=0.00001,
+        cache=0.00000031,
+    ),
+    "deepseek/deepseek-chat-v3-0324": LLMCost(
+        name="deepseek/deepseek-chat-v3-0324",
+        prompt=0.0000001999188,
+        completion=0.000000800064,
+    ),
+    "anthropic/claude-3.7-sonnet": LLMCost(
+        name="anthropic/claude-3.7-sonnet",
+        prompt=0.000003,
+        completion=0.000015,
+        cache=0.0000003,
+    ),
+}

--- a/src/budgetbench/runner.py
+++ b/src/budgetbench/runner.py
@@ -65,7 +65,8 @@ def run_humaneval_task(
     """
     dataset = load_dataset("openai/openai_humaneval", split="test")
     problem = next(p for p in dataset if p["task_id"] == task_id)
-    raw = chat_completion(problem["prompt"], model=model, max_tokens=max_tokens)
+    completion = chat_completion(problem["prompt"], model=model, max_tokens=max_tokens)
+    raw = completion["message"]
     code = _extract_code(raw)
     is_valid = _is_valid_python(code)
     has_valid_signature = _has_valid_signature(code, problem["prompt"], problem["entry_point"])

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,52 @@
+import types
+
+import pytest
+
+from budgetbench.llm import chat_completion
+from budgetbench.llm_cost import LLM_COSTS
+
+
+def test_chat_completion_usage_and_cost(monkeypatch):
+    class DummyCompletion:
+        def __init__(self):
+            message = types.SimpleNamespace(content="hello")
+            self.choices = [types.SimpleNamespace(message=message)]
+            self.usage = types.SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                cache_creation_input_tokens=2,
+                cache_read_input_tokens=3,
+                reasoning_tokens=4,
+            )
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            pass
+
+        class chat:  # noqa: D401 - simple namespace
+            class completions:  # noqa: D401 - simple namespace
+                @staticmethod
+                def create(**kwargs):
+                    return DummyCompletion()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr("budgetbench.llm.OpenAI", lambda **kwargs: DummyClient())
+    result = chat_completion("prompt", model="openai/gpt-5")
+    assert result["message"] == "hello"
+    assert result["usage"] == {
+        "prompt_tokens": 10,
+        "cache_tokens": 5,
+        "reasoning_tokens": 4,
+        "completion_tokens": 5,
+    }
+    cost_info = LLM_COSTS["openai/gpt-5"]
+    assert result["cost"]["prompt"] == pytest.approx(10 * cost_info.prompt)
+    assert result["cost"]["cache"] == pytest.approx(5 * cost_info.cache)
+    assert result["cost"]["completion"] == pytest.approx(5 * cost_info.completion)
+    assert result["cost"]["reasoning"] == pytest.approx(4 * cost_info.reasoning)
+    assert result["cost"]["total"] == pytest.approx(
+        result["cost"]["prompt"]
+        + result["cost"]["cache"]
+        + result["cost"]["reasoning"]
+        + result["cost"]["completion"]
+    )

--- a/tests/test_llm_cost_integration.py
+++ b/tests/test_llm_cost_integration.py
@@ -1,0 +1,32 @@
+"""Integration test for cost tracking in chat completion."""
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from budgetbench.llm import chat_completion
+from budgetbench.llm_cost import LLM_COSTS
+
+
+@pytest.mark.integration
+def test_chat_completion_includes_costs():
+    if not os.getenv("OPENAI_API_KEY") or not os.getenv("OPENAI_BASE_URL"):
+        load_dotenv()
+    if not os.getenv("OPENAI_API_KEY"):
+        pytest.fail("OPENAI_API_KEY must be set for integration test")
+
+    model = "openai/gpt-oss-20b"
+    result = chat_completion("Say hello world", model=model)
+
+    usage = result["usage"]
+    cost = result["cost"]
+    cost_info = LLM_COSTS[model]
+
+    assert cost["prompt"] == pytest.approx(usage["prompt_tokens"] * cost_info.prompt)
+    assert cost["cache"] == pytest.approx(usage["cache_tokens"] * cost_info.cache)
+    assert cost["reasoning"] == pytest.approx(usage["reasoning_tokens"] * cost_info.reasoning)
+    assert cost["completion"] == pytest.approx(usage["completion_tokens"] * cost_info.completion)
+    assert cost["total"] == pytest.approx(
+        cost["prompt"] + cost["cache"] + cost["reasoning"] + cost["completion"]
+    )

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -15,5 +15,5 @@ def test_openai_hello_world():
     if not os.getenv("OPENAI_API_KEY"):
         pytest.fail("OPENAI_API_KEY must be set for integration test")
     result = chat_completion("Say hello world")
-    normalized = result.lower().replace(",", "")
+    normalized = result["message"].lower().replace(",", "")
     assert "hello world" in normalized


### PR DESCRIPTION
## Summary
- add OpenRouter pricing table and dataclass for supported models
- expose detailed token usage and cost from `chat_completion`
- adjust runner and tests for new return format
- add unit and integration tests covering cost calculations

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68b644d7f9b8832b90b52d9585eaa5de