### PR TITLE
Add budget-based HumanEval runner and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "python-dotenv>=1.1.1",
 ]
 
+[project.scripts]
+budgetbench-run = "budgetbench.cli:main"
+
 [tool.pytest.ini_options]
 markers = [
     "integration: tests that call external LLM providers",

--- a/src/budgetbench/__init__.py
+++ b/src/budgetbench/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for BudgetBench."""
+
+from .runner import run_humaneval_task, run_humaneval_until_budget
+
+__all__ = ["run_humaneval_task", "run_humaneval_until_budget"]

--- a/src/budgetbench/cli.py
+++ b/src/budgetbench/cli.py
@@ -1,0 +1,32 @@
+"""Command line interface for BudgetBench budget runner."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .runner import run_humaneval_until_budget
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run HumanEval tasks with an LLM until a budget is exhausted"
+    )
+    parser.add_argument("model", help="Model name to evaluate")
+    parser.add_argument("budget", type=float, help="Budget in USD")
+    parser.add_argument(
+        "--log-dir", default="logs", help="Directory to store JSON log files"
+    )
+    args = parser.parse_args()
+
+    summary = run_humaneval_until_budget(
+        model=args.model, budget=args.budget, log_dir=Path(args.log_dir)
+    )
+    print(
+        f"Attempts: {summary['attempts']}\n"
+        f"Correct: {summary['correct']}\n"
+        f"Total cost: ${summary['total_cost']:.6f}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_budget_runner_integration.py
+++ b/tests/test_budget_runner_integration.py
@@ -1,0 +1,25 @@
+"""Integration test for running tasks within a budget."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from budgetbench.runner import run_humaneval_until_budget
+
+
+@pytest.mark.integration
+def test_run_humaneval_until_budget(tmp_path: Path) -> None:
+    result = run_humaneval_until_budget(
+        model="openai/gpt-oss-120b", budget=0.001, log_dir=tmp_path
+    )
+    assert result["attempts"] > 0
+    assert result["correct"] >= 0
+    assert result["total_cost"] >= 0.001
+
+    logs = list(tmp_path.glob("*.json"))
+    assert logs, "no log files written"
+    with logs[0].open() as fh:
+        data = json.load(fh)
+    assert {"task_id", "model", "response", "correct", "cost"} <= data.keys()


### PR DESCRIPTION
## Summary
- track LLM costs per HumanEval task and expose `run_humaneval_until_budget` to loop until a budget is depleted, logging each attempt with a UUID filename and model details
- provide `budgetbench-run` CLI to run the loop and log each attempt to JSON
- add integration test exercising the budget runner

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68b653407d18832b99b57b7f725c01ab