### PR TITLE
Add budget-based HumanEval runner with analytics modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "python-dotenv>=1.1.1",
 ]
 
+[project.scripts]
+budgetbench-run = "budgetbench.cli:main"
+
 [tool.pytest.ini_options]
 markers = [
     "integration: tests that call external LLM providers",

--- a/src/budgetbench/__init__.py
+++ b/src/budgetbench/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for BudgetBench."""
+
+from .runner import run_humaneval_task, run_humaneval_until_budget
+
+__all__ = ["run_humaneval_task", "run_humaneval_until_budget"]

--- a/src/budgetbench/cli.py
+++ b/src/budgetbench/cli.py
@@ -1,0 +1,52 @@
+"""Command line interface for BudgetBench budget runner."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .runner import run_humaneval_until_budget
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run HumanEval tasks with an LLM until a budget is exhausted"
+    )
+    parser.add_argument("model", help="Model name to evaluate")
+    parser.add_argument("budget", type=float, help="Budget in USD")
+    parser.add_argument(
+        "--log-dir", default="logs", help="Directory to store JSON log files"
+    )
+    parser.add_argument(
+        "--analytics",
+        choices=["simple", "full"],
+        help="Include analytics output (simple or full)",
+    )
+    args = parser.parse_args()
+
+    summary = run_humaneval_until_budget(
+        model=args.model, budget=args.budget, log_dir=Path(args.log_dir)
+    )
+    print(
+        f"Attempts: {summary['attempts']}\n"
+        f"Correct: {summary['correct']}\n"
+        f"Total cost: ${summary['total_cost']:.6f}"
+    )
+
+    if args.analytics == "simple":
+        print(
+            "Analytics (simple):\n"
+            f"  Correct problems: {summary['correct']}\n"
+            f"  Total attempts: {summary['attempts']}\n"
+            f"  Total cost: ${summary['total_cost']:.6f}"
+        )
+    elif args.analytics == "full":
+        print("Analytics (full):")
+        for task_id, stats in summary["per_problem"].items():
+            if stats["attempts"]:
+                print(
+                    f"  {task_id}: attempts={stats['attempts']}, correct={stats['correct']}"
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/budgetbench/runner.py
+++ b/src/budgetbench/runner.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import ast
+import json
 import re
-from typing import Any, Dict
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable
 
 from datasets import load_dataset
 
@@ -55,21 +58,26 @@ def run_humaneval_task(
     task_id: str,
     model: str,
     max_tokens: int = 10_240,
+    dataset: Iterable[Dict[str, Any]] | None = None,
 ) -> Dict[str, Any]:
     """Generate and evaluate a HumanEval task using ``model``.
 
-    The returned dictionary contains the raw LLM output (``raw``), the extracted
-    code (``code``), booleans for syntax validity (``is_valid``) and API
-    compliance (``has_valid_signature``), along with the evaluation results
-    (``passed`` and ``total``).
+    ``dataset`` may be provided to avoid repeated downloads when evaluating many
+    tasks. The returned dictionary contains the raw LLM output (``raw``), the
+    extracted code (``code``), booleans for syntax validity (``is_valid``) and
+    API compliance (``has_valid_signature``), along with the evaluation results
+    (``passed`` and ``total``) and token ``cost`` information.
     """
-    dataset = load_dataset("openai/openai_humaneval", split="test")
+    if dataset is None:
+        dataset = load_dataset("openai/openai_humaneval", split="test")
     problem = next(p for p in dataset if p["task_id"] == task_id)
     completion = chat_completion(problem["prompt"], model=model, max_tokens=max_tokens)
     raw = completion["message"]
     code = _extract_code(raw)
     is_valid = _is_valid_python(code)
-    has_valid_signature = _has_valid_signature(code, problem["prompt"], problem["entry_point"])
+    has_valid_signature = _has_valid_signature(
+        code, problem["prompt"], problem["entry_point"]
+    )
     passed, total = evaluate(problem, code)
     return {
         "raw": raw,
@@ -78,4 +86,74 @@ def run_humaneval_task(
         "has_valid_signature": has_valid_signature,
         "passed": passed,
         "total": total,
+        "cost": completion.get("cost", {}),
+    }
+
+
+def run_humaneval_until_budget(
+    model: str,
+    budget: float,
+    log_dir: Path = Path("logs"),
+    max_tokens: int = 10_240,
+) -> Dict[str, Any]:
+    """Run HumanEval tasks until ``budget`` (USD) is exhausted.
+
+    Tasks are attempted sequentially and repeatedly until either all tasks are
+    solved or the running cost exceeds ``budget``. Each attempt is logged as a
+    JSON file named with a UUID in ``log_dir`` containing the task identifier,
+    model name, raw LLM response, correctness flag and detailed cost
+    information.
+
+    The returned dictionary summarises the number of ``attempts``, how many were
+    ``correct`` and the ``total_cost`` spent.
+    """
+    dataset = load_dataset("openai/openai_humaneval", split="test")
+    tasks = [p["task_id"] for p in dataset]
+    unsolved = tasks.copy()
+    attempts = 0
+    total_cost = 0.0
+    solved = set()
+    problem_stats = {task_id: {"attempts": 0, "correct": False} for task_id in tasks}
+    log_dir.mkdir(parents=True, exist_ok=True)
+    idx = 0
+
+    while unsolved and total_cost < budget:
+        task_id = unsolved[idx]
+        attempts += 1
+        result = run_humaneval_task(
+            task_id, model=model, max_tokens=max_tokens, dataset=dataset
+        )
+        problem_stats[task_id]["attempts"] += 1
+        correct = result["passed"] == result["total"]
+        problem_stats[task_id]["correct"] = problem_stats[task_id]["correct"] or correct
+        cost = float(result.get("cost", {}).get("total", 0.0))
+        total_cost += cost
+
+        log_id = uuid.uuid4()
+        log_data = {
+            "id": str(log_id),
+            "model": model,
+            "task_id": task_id,
+            "response": result["raw"],
+            "correct": correct,
+            "cost": result.get("cost", {}),
+        }
+        log_file = log_dir / f"{log_id}.json"
+        with log_file.open("w") as fh:
+            json.dump(log_data, fh)
+
+        if correct:
+            solved.add(task_id)
+            unsolved.pop(idx)
+            if not unsolved:
+                break
+            idx %= len(unsolved)
+        else:
+            idx = (idx + 1) % len(unsolved)
+
+    return {
+        "attempts": attempts,
+        "correct": len(solved),
+        "total_cost": total_cost,
+        "per_problem": problem_stats,
     }

--- a/tests/test_budget_runner_integration.py
+++ b/tests/test_budget_runner_integration.py
@@ -1,0 +1,27 @@
+"""Integration test for running tasks within a budget."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from budgetbench.runner import run_humaneval_until_budget
+
+
+@pytest.mark.integration
+def test_run_humaneval_until_budget(tmp_path: Path) -> None:
+    result = run_humaneval_until_budget(
+        model="openai/gpt-oss-120b", budget=0.001, log_dir=tmp_path
+    )
+    assert result["attempts"] > 0
+    assert result["correct"] >= 0
+    assert result["total_cost"] >= 0.001
+    assert "per_problem" in result
+    assert any(s["attempts"] > 0 for s in result["per_problem"].values())
+
+    logs = list(tmp_path.glob("*.json"))
+    assert logs, "no log files written"
+    with logs[0].open() as fh:
+        data = json.load(fh)
+    assert {"task_id", "model", "response", "correct", "cost"} <= data.keys()


### PR DESCRIPTION
## Summary
- track per-problem statistics in the budget runner to enable analytics summaries
- extend `budgetbench-run` CLI with optional `--analytics` flag supporting `simple` and `full` reports
- validate per-problem tracking in integration tests

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration` *(fails: model did not produce valid Python code)*

------
https://chatgpt.com/codex/tasks/task_e_68b653407d18832b99b57b7f725c01ab