### PR TITLE
Add OpenRouter model pricing entries

### DIFF
--- a/src/budgetbench/llm_cost.py
+++ b/src/budgetbench/llm_cost.py
@@ -100,4 +100,30 @@ LLM_COSTS: dict[str, LLMCost] = {
         completion=0.000015,
         cache=0.0000003,
     ),
+    "deepseek/deepseek-chat-v3.1": LLMCost(
+        name="deepseek/deepseek-chat-v3.1",
+        prompt=0.0000002,
+        completion=0.0000008,
+    ),
+    "z-ai/glm-4.5v": LLMCost(
+        name="z-ai/glm-4.5v",
+        prompt=0.0000005,
+        completion=0.0000018,
+    ),
+    "mistralai/codestral-2508": LLMCost(
+        name="mistralai/codestral-2508",
+        prompt=0.0000003,
+        completion=0.0000009,
+    ),
+    "x-ai/grok-4": LLMCost(
+        name="x-ai/grok-4",
+        prompt=0.000003,
+        completion=0.000015,
+        cache=0.00000075,
+    ),
+    "deepseek/deepseek-r1-0528": LLMCost(
+        name="deepseek/deepseek-r1-0528",
+        prompt=0.0000001999188,
+        completion=0.000000800064,
+    ),
 }


### PR DESCRIPTION
## Summary
- add llm_cost entries for deepseek/deepseek-chat-v3.1, z-ai/glm-4.5v, mistralai/codestral-2508, x-ai/grok-4, and deepseek/deepseek-r1-0528

## Testing
- `uv run pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b79f40d914832ba964cc6e21616212