### PR TITLE
Add scripts to run models and aggregate results

### DIFF
--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Aggregate BudgetBench logs into CSV reports.
+
+Two CSV files are produced:
+
+``per_call.csv``
+    One row per attempt with columns for model, run identifier, task, correctness
+    and token cost components.
+
+``aggregate_by_budget.csv``
+    For each run and budget threshold (0.001, 0.01, 0.1, 1, 10 USD) report the
+    number of problems solved and corresponding pass rate.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List
+
+BUDGETS = [0.001, 0.01, 0.1, 1, 10]
+
+
+def _read_attempts(run_dir: Path) -> List[Dict]:
+    """Return attempts for ``run_dir`` ordered chronologically."""
+    jsonl = run_dir / "attempts.jsonl"
+    attempts: List[Dict] = []
+    if jsonl.exists():
+        with jsonl.open() as fh:
+            for line in fh:
+                attempts.append(json.loads(line))
+        return attempts
+
+    files = [
+        p
+        for p in run_dir.glob("*.json")
+        if p.name not in {"summary.json", "metadata.json", "attempts.jsonl"}
+    ]
+    files.sort(key=lambda p: p.stat().st_mtime)
+    for path in files:
+        with path.open() as fh:
+            attempts.append(json.load(fh))
+    return attempts
+
+
+def aggregate(log_dir: Path, out_dir: Path) -> None:
+    per_call_path = out_dir / "per_call.csv"
+    agg_path = out_dir / "aggregate_by_budget.csv"
+
+    per_call_rows = []
+    agg_rows = []
+
+    for jsonl in log_dir.rglob("attempts.jsonl"):
+        run_dir = jsonl.parent
+        attempts = _read_attempts(run_dir)
+        if not attempts:
+            continue
+        run_id = run_dir.name
+        model = attempts[0]["model"]
+        summary_file = run_dir / "summary.json"
+        total_tasks = None
+        if summary_file.exists():
+            with summary_file.open() as fh:
+                summary = json.load(fh)
+            total_tasks = len(summary.get("per_problem", {})) or None
+
+        for att in attempts:
+            cost = att.get("cost", {})
+            per_call_rows.append(
+                {
+                    "model": att.get("model"),
+                    "run_id": run_id,
+                    "task_id": att.get("task_id"),
+                    "correct": att.get("correct"),
+                    "cost_total": cost.get("total"),
+                    "cost_prompt": cost.get("prompt"),
+                    "cost_completion": cost.get("completion"),
+                    "cost_cache": cost.get("cache"),
+                    "cost_reasoning": cost.get("reasoning"),
+                }
+            )
+
+        solved = set()
+        cumulative = 0.0
+        counts = {}
+        budget_idx = 0
+        sorted_budgets = sorted(BUDGETS)
+        for att in attempts:
+            cumulative += float(att.get("cost", {}).get("total", 0.0))
+            if att.get("correct") and att.get("task_id") not in solved:
+                solved.add(att["task_id"])
+            while budget_idx < len(sorted_budgets) and cumulative >= sorted_budgets[budget_idx]:
+                counts[sorted_budgets[budget_idx]] = len(solved)
+                budget_idx += 1
+        for i in range(budget_idx, len(sorted_budgets)):
+            counts[sorted_budgets[i]] = len(solved)
+
+        for b in sorted_budgets:
+            row = {
+                "model": model,
+                "run_id": run_id,
+                "budget": b,
+                "solved": counts.get(b, 0),
+            }
+            if total_tasks:
+                row["pass_rate"] = counts.get(b, 0) / total_tasks
+            agg_rows.append(row)
+
+    per_call_path.parent.mkdir(parents=True, exist_ok=True)
+    with per_call_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            [
+                "model",
+                "run_id",
+                "task_id",
+                "correct",
+                "cost_total",
+                "cost_prompt",
+                "cost_completion",
+                "cost_cache",
+                "cost_reasoning",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(per_call_rows)
+
+    with agg_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, ["model", "run_id", "budget", "solved", "pass_rate"])
+        writer.writeheader()
+        writer.writerows(agg_rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Aggregate BudgetBench logs")
+    parser.add_argument("log_dir", type=Path, help="Directory containing run logs")
+    parser.add_argument(
+        "--out-dir", type=Path, default=Path("."), help="Directory for CSV output"
+    )
+    args = parser.parse_args()
+    aggregate(args.log_dir, args.out_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/scripts/run_all_models.py
+++ b/scripts/run_all_models.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run HumanEval for every model listed in ``LLM_COSTS``.
+
+Each model is evaluated with ``run_humaneval_until_budget`` and logs are
+stored under ``logs/humaneval/<model>/<run-id>`` where ``run-id`` is a
+UTC timestamp.  After each run a ``summary.json`` and ``metadata.json``
+are written alongside the per-attempt JSON logs produced by the runner.
+An ``attempts.jsonl`` file is also generated to provide a compact view of
+all attempts in chronological order.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from budgetbench.llm_cost import LLM_COSTS
+from budgetbench.runner import run_humaneval_until_budget
+
+
+def _build_attempts_jsonl(log_dir: Path) -> None:
+    """Create ``attempts.jsonl`` by concatenating individual attempt logs."""
+    attempt_files = [
+        p
+        for p in log_dir.glob("*.json")
+        if p.name not in {"summary.json", "metadata.json", "attempts.jsonl"}
+    ]
+    attempt_files.sort(key=lambda p: p.stat().st_mtime)
+    jsonl = log_dir / "attempts.jsonl"
+    with jsonl.open("w") as out:
+        for path in attempt_files:
+            with path.open() as fh:
+                out.write(fh.read().strip())
+                out.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run all models in LLM_COSTS")
+    parser.add_argument(
+        "--budget",
+        type=float,
+        default=10.0,
+        help="Budget in USD for each model run",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default="logs",
+        help="Base directory to store run logs",
+    )
+    args = parser.parse_args()
+
+    base_dir = Path(args.log_dir)
+    for model in LLM_COSTS:
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        model_dir = model.replace("/", "_")
+        log_dir = base_dir / "humaneval" / model_dir / run_id
+        summary = run_humaneval_until_budget(
+            model=model, budget=args.budget, log_dir=log_dir, show_progress=True
+        )
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+        metadata = {"model": model, "budget": args.budget, "run_id": run_id}
+        (log_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+        _build_attempts_jsonl(log_dir)
+        print(
+            f"{model}: attempts={summary['attempts']} correct={summary['correct']} cost=${summary['total_cost']:.4f}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- Add `run_all_models.py` to evaluate every LLM defined in `LLM_COSTS` and store logs, summaries, and metadata
- Add `aggregate_results.py` to transform log directories into per-attempt and budget-sliced CSV reports

## Testing
- `uv run pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b8e7956198832bbdee21bef26af4e8