### PR TITLE
Add GSM8K evaluation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # BudgetBench
 
-BudgetBench: A cost-aware benchmark for LLM coding. Tracks HumanEval+ pass@k alongside token spend, letting you compare models by accuracy per dollar.
+BudgetBench: A cost-aware benchmark for LLM reasoning and coding. It tracks
+dataset pass rates alongside token spend, letting you compare models by
+accuracy per dollar. The framework supports both the coding-focused HumanEval
+suite and the GSM8K mathematics dataset.
 
 ## Development
 
-This project uses [uv](https://github.com/astral-sh/uv) for dependency management and relies on the public HumanEval dataset and evaluation library.
+This project uses [uv](https://github.com/astral-sh/uv) for dependency management and relies on the public HumanEval and GSM8K datasets along with the official evaluation utilities.
 
 ```bash
 uv sync
@@ -13,7 +16,7 @@ uv run pytest -m integration # run only integration tests
 uv run pytest -m "not integration" # run tests excluding integration
 ```
 
-The included tests download the ``openai/openai_humaneval`` dataset and evaluate two of its problems (``make_palindrome`` and ``fizz_buzz``) with correct, partially correct, and incorrect solutions using the official ``human_eval`` executor.
+The included tests download the ``openai/openai_humaneval`` dataset and evaluate two of its problems (``make_palindrome`` and ``fizz_buzz``) with correct, partially correct, and incorrect solutions using the official ``human_eval`` executor. Additional unit tests exercise the GSM8K evaluation helper.
 
 ### LLM integration tests
 

--- a/src/budgetbench/__init__.py
+++ b/src/budgetbench/__init__.py
@@ -1,5 +1,15 @@
 """Public API for BudgetBench."""
 
-from .runner import run_humaneval_task, run_humaneval_until_budget
+from .runner import (
+    run_gsm8k_task,
+    run_gsm8k_until_budget,
+    run_humaneval_task,
+    run_humaneval_until_budget,
+)
 
-__all__ = ["run_humaneval_task", "run_humaneval_until_budget"]
+__all__ = [
+    "run_humaneval_task",
+    "run_humaneval_until_budget",
+    "run_gsm8k_task",
+    "run_gsm8k_until_budget",
+]

--- a/src/budgetbench/cli.py
+++ b/src/budgetbench/cli.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from .runner import run_humaneval_until_budget
+from .runner import run_gsm8k_until_budget, run_humaneval_until_budget
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run HumanEval tasks with an LLM until a budget is exhausted"
+        description="Run evaluation tasks with an LLM until a budget is exhausted"
     )
     parser.add_argument("model", help="Model name to evaluate")
     parser.add_argument("budget", type=float, help="Budget in USD")
@@ -21,14 +21,28 @@ def main() -> None:
         choices=["simple", "full"],
         help="Include analytics output (simple or full)",
     )
+    parser.add_argument(
+        "--dataset",
+        choices=["humaneval", "gsm8k"],
+        default="humaneval",
+        help="Dataset to evaluate",
+    )
     args = parser.parse_args()
 
-    summary = run_humaneval_until_budget(
-        model=args.model,
-        budget=args.budget,
-        log_dir=Path(args.log_dir),
-        show_progress=True,
-    )
+    if args.dataset == "humaneval":
+        summary = run_humaneval_until_budget(
+            model=args.model,
+            budget=args.budget,
+            log_dir=Path(args.log_dir),
+            show_progress=True,
+        )
+    else:
+        summary = run_gsm8k_until_budget(
+            model=args.model,
+            budget=args.budget,
+            log_dir=Path(args.log_dir),
+            show_progress=True,
+        )
     print(
         f"Attempts: {summary['attempts']}\n"
         f"Correct: {summary['correct']}\n"

--- a/tests/test_gsm8k_runner.py
+++ b/tests/test_gsm8k_runner.py
@@ -1,0 +1,31 @@
+import budgetbench.runner as runner
+
+def test_run_gsm8k_task(monkeypatch):
+    dataset = [{
+        "question": "What is 2 + 2?",
+        "answer": "Add the numbers to get 4. #### 4",
+    }]
+
+    def fake_chat(prompt, model, max_tokens):
+        assert prompt == "What is 2 + 2?"
+        return {"message": "The answer is 4", "cost": {"total": 0.0}}
+
+    monkeypatch.setattr(runner, "chat_completion", fake_chat)
+    result = runner.run_gsm8k_task(0, model="test-model", dataset=dataset)
+    assert result["passed"] == 1
+    assert result["answer"] == "4"
+    assert result["total"] == 1
+
+
+def test_run_gsm8k_task_incorrect(monkeypatch):
+    dataset = [{
+        "question": "What is 2 + 2?",
+        "answer": "Add the numbers to get 4. #### 4",
+    }]
+
+    def fake_chat(prompt, model, max_tokens):
+        return {"message": "5", "cost": {"total": 0.0}}
+
+    monkeypatch.setattr(runner, "chat_completion", fake_chat)
+    result = runner.run_gsm8k_task(0, model="test-model", dataset=dataset)
+    assert result["passed"] == 0

--- a/tests/test_run_all_models.py
+++ b/tests/test_run_all_models.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+import importlib.util
+
+import pytest
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parent.parent / "scripts" / "run_all_models.py"
+    spec = importlib.util.spec_from_file_location("run_all_models", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_all_models_subset(monkeypatch, tmp_path):
+    run_all_models = _load_module()
+    called = []
+
+    def fake_run_model(model, budget, base_dir, show_progress):  # pragma: no cover - test helper
+        called.append(model)
+
+    monkeypatch.setattr(run_all_models, "_run_model", fake_run_model)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_all_models.py",
+            "--log-dir",
+            str(tmp_path),
+            "--models",
+            "openai/gpt-5",
+            "openai/gpt-5-mini",
+        ],
+    )
+    run_all_models.main()
+    assert called == ["openai/gpt-5", "openai/gpt-5-mini"]
+
+
+def test_run_all_models_unknown_model(monkeypatch, tmp_path):
+    run_all_models = _load_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_all_models.py",
+            "--log-dir",
+            str(tmp_path),
+            "--models",
+            "unknown/model",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        run_all_models.main()


### PR DESCRIPTION
## Summary
- add GSM8K dataset support with task runner and budget utilities
- expose GSM8K functions through CLI and package API
- document new GSM8K capability and test helper

## Testing
- `uv run pytest -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_68c0baa363b4832b9e4bbec3afcf3dbd